### PR TITLE
Update mcs-winui3-app template

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Promotes conciseness, readability and leveraging the latest language features.
 - **mcs-orleans-multiservice** [doc](https://github.com/Applicita/Orleans.Multiservice#readme)<br />
   *Prevent microservices pain with logical service separation for Microsoft Orleans 7*
 
-These templates can be combined with [Orleans.Multitenant](https://github.com/Applicita/Orleans.Multitenant) for secure, flexible tenant separation in Microsoft Orleans 7
+The Orleans templates can be combined with [Orleans.Multitenant](https://github.com/Applicita/Orleans.Multitenant) for secure, flexible tenant separation in Microsoft Orleans 7
 
 For how to install, see:<br />
 [![Nuget (with prereleases)](https://img.shields.io/nuget/vpre/Modern.CSharp.Templates?color=gold&label=NuGet:%20Modern.CSharp.Templates&style=plastic)](https://www.nuget.org/packages/Modern.CSharp.Templates)

--- a/src/Modern.CSharp.Templates.csproj
+++ b/src/Modern.CSharp.Templates.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <PackageId>Modern.CSharp.Templates</PackageId>
-        <PackageVersion>1.2.2</PackageVersion>
+        <PackageVersion>1.3.0</PackageVersion>
         <PackageType>Template</PackageType>
         <Title>Modern C# 11 Templates</Title>
         <Description>A toolkit of modern dotnet new templates for C# 11, .NET 7, Microsoft Orleans 7, Windows App SDK and Uno Platform</Description>

--- a/src/Modern.CSharp.Templates.csproj
+++ b/src/Modern.CSharp.Templates.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <PackageId>Modern.CSharp.Templates</PackageId>
-        <PackageVersion>1.2.1</PackageVersion>
+        <PackageVersion>1.2.2</PackageVersion>
         <PackageType>Template</PackageType>
         <Title>Modern C# 11 Templates</Title>
         <Description>A toolkit of modern dotnet new templates for C# 11, .NET 7, Microsoft Orleans 7, Windows App SDK and Uno Platform</Description>

--- a/src/Modern.CSharp.Templates.csproj
+++ b/src/Modern.CSharp.Templates.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <PackageId>Modern.CSharp.Templates</PackageId>
-        <PackageVersion>1.2.0</PackageVersion>
+        <PackageVersion>1.2.1</PackageVersion>
         <PackageType>Template</PackageType>
         <Title>Modern C# 11 Templates</Title>
         <Description>A toolkit of modern dotnet new templates for C# 11, .NET 7, Microsoft Orleans 7, Windows App SDK and Uno Platform</Description>

--- a/src/Orleans.Multiservice/Apis/Apis.csproj
+++ b/src/Orleans.Multiservice/Apis/Apis.csproj
@@ -19,10 +19,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+        <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="7.1.0" />
+        <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.1.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Orleans.Multiservice/Contracts/Contracts.csproj
+++ b/src/Orleans.Multiservice/Contracts/Contracts.csproj
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.1.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Orleans.Multiservice/LogicalserviceNameService/LogicalserviceNameService.csproj
+++ b/src/Orleans.Multiservice/LogicalserviceNameService/LogicalserviceNameService.csproj
@@ -14,8 +14,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Runtime" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Runtime" Version="7.1.0" />
+        <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Orleans.Multiservice/Readme.md
+++ b/src/Orleans.Multiservice/Readme.md
@@ -1,7 +1,7 @@
 # MultiserviceName multiservice
 
 ## The multiservice pattern 
-This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/Applicita/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 1.1.0](https://www.nuget.org/packages/Modern.CSharp.Templates/1.1.0) by this command:
+This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/Applicita/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 1.2.2](https://www.nuget.org/packages/Modern.CSharp.Templates/1.2.2) by this command:
 
 `dotnet new mcs-orleans-multiservice --RootNamespace RootNamespacePrefix --Multiservice MultiserviceName --Logicalservice LogicalserviceName`
 

--- a/src/Orleans.Multiservice/Readme.md
+++ b/src/Orleans.Multiservice/Readme.md
@@ -1,7 +1,7 @@
 # MultiserviceName multiservice
 
 ## The multiservice pattern 
-This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/Applicita/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 1.2.2](https://www.nuget.org/packages/Modern.CSharp.Templates/1.2.2) by this command:
+This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/Applicita/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 1.3.0](https://www.nuget.org/packages/Modern.CSharp.Templates/1.3.0) by this command:
 
 `dotnet new mcs-orleans-multiservice --RootNamespace RootNamespacePrefix --Multiservice MultiserviceName --Logicalservice LogicalserviceName`
 

--- a/src/Readme.md
+++ b/src/Readme.md
@@ -1,23 +1,28 @@
 ﻿A toolkit of modern [dotnet new templates](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-new) for C# 11, .NET 7, Microsoft Orleans 7, Windows App SDK and Uno Platform
 
 Templates:
-- **mcs-editorconfig** [doc](https://github.com/Applicita/Modern.CSharp.Templates/blob/main/Editorconfig.md)<br />
+- **mcs-editorconfig** [doc](https://github.com/Applicita/Modern.CSharp.Templates/blob/main/Editorconfig.md)
+
   *Settings for C# 11 code formatting, style, naming style and analysis.
 Promotes conciseness, readability and leveraging the latest language features.
 (can also be used with C# 10)*
 
-- **mcs-winui3-app** [doc](https://github.com/VincentH-Net/CSharpForMarkup#readme)<br />
+- **mcs-winui3-app** [doc](https://github.com/VincentH-Net/CSharpForMarkup#readme)
+
   *WinUI 3 C# Markup 2 application solution template for building browser / native UI with Windows App SDK and/or Uno Platform*
 
-- **mcs-winui3-view** [doc](https://github.com/VincentH-Net/CSharpForMarkup#readme)<br />
+- **mcs-winui3-view** [doc](https://github.com/VincentH-Net/CSharpForMarkup#readme)
+
   *WinUI 3 C# Markup 2 view item template, for use with the `mcs-winui3-app` template via it's `New-View.ps1` command*
 
-- **mcs-orleans-results** [doc](https://github.com/Applicita/Orleans.Results#readme)<br />
+- **mcs-orleans-results** [doc](https://github.com/Applicita/Orleans.Results#readme)
+
   *Concise, version-tolerant result pattern implementation for Microsoft Orleans 7*
 
-- **mcs-orleans-multiservice** [doc](https://github.com/Applicita/Orleans.Multiservice#readme)<br />
+- **mcs-orleans-multiservice** [doc](https://github.com/Applicita/Orleans.Multiservice#readme)
+
   *Prevent microservices pain with logical service separation for Microsoft Orleans 7*
 
-These templates can be combined with [Orleans.Multitenant](https://github.com/Applicita/Orleans.Multitenant) for secure, flexible tenant separation in Microsoft Orleans 7
+The Orleans templates can be combined with [Orleans.Multitenant](https://github.com/Applicita/Orleans.Multitenant) for secure, flexible tenant separation in Microsoft Orleans 7
 
 [Release Notes](https://github.com/Applicita/Modern.CSharp.Templates/releases/tag/1-2-0)

--- a/src/Readme.md
+++ b/src/Readme.md
@@ -25,4 +25,4 @@ Promotes conciseness, readability and leveraging the latest language features.
 
 The Orleans templates can be combined with [Orleans.Multitenant](https://github.com/Applicita/Orleans.Multitenant) for secure, flexible tenant separation in Microsoft Orleans 7
 
-[Release Notes](https://github.com/Applicita/Modern.CSharp.Templates/releases/tag/1-2-0)
+[Release Notes](https://github.com/Applicita/Modern.CSharp.Templates/releases/tag/1-3-0)

--- a/src/WinUI3-App/UnoWinUIQuickStart.Mobile/UnoWinUIQuickStart.Mobile.csproj
+++ b/src/WinUI3-App/UnoWinUIQuickStart.Mobile/UnoWinUIQuickStart.Mobile.csproj
@@ -48,11 +48,11 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.WinUI" Version="4.7.44" />
-    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.44" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.44" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Uno.WinUI.Lottie" Version="4.7.44" />
+    <PackageReference Include="Uno.WinUI" Version="4.9.20" />
+    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.20" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.20" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="Uno.WinUI.Lottie" Version="4.9.20" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(TargetFramework)'=='net7.0-android'">

--- a/src/WinUI3-App/UnoWinUIQuickStart.Server/UnoWinUIQuickStart.Server.csproj
+++ b/src/WinUI3-App/UnoWinUIQuickStart.Server/UnoWinUIQuickStart.Server.csproj
@@ -16,7 +16,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.Wasm.Bootstrap.Server" Version="7.0.0-dev.195" />
+		<PackageReference Include="Uno.Wasm.Bootstrap.Server" Version="7.0.24" />
 	</ItemGroup>
 #endif -->
 

--- a/src/WinUI3-App/UnoWinUIQuickStart.Skia.Gtk/UnoWinUIQuickStart.Skia.Gtk.csproj
+++ b/src/WinUI3-App/UnoWinUIQuickStart.Skia.Gtk/UnoWinUIQuickStart.Skia.Gtk.csproj
@@ -15,11 +15,11 @@
     <Content Include="..\UnoWinUIQuickStart.Windows\Images\StoreLogo.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.44" />
-    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.44" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.44" />
-    <PackageReference Include="Uno.WinUI.Lottie" Version="4.7.44" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.9.20" />
+    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.20" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.20" />
+    <PackageReference Include="Uno.WinUI.Lottie" Version="4.9.20" />
     <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
     <PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
   </ItemGroup>

--- a/src/WinUI3-App/UnoWinUIQuickStart.Skia.Linux.FrameBuffer/UnoWinUIQuickStart.Skia.Linux.FrameBuffer.csproj
+++ b/src/WinUI3-App/UnoWinUIQuickStart.Skia.Linux.FrameBuffer/UnoWinUIQuickStart.Skia.Linux.FrameBuffer.csproj
@@ -15,11 +15,11 @@
     <Content Include="..\UnoWinUIQuickStart.Windows\Images\StoreLogo.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.44" />
-    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.44" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.44" />
-    <PackageReference Include="Uno.WinUI.Lottie" Version="4.7.44" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.9.20" />
+    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.20" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.20" />
+    <PackageReference Include="Uno.WinUI.Lottie" Version="4.9.20" />
     <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
     <PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
   </ItemGroup>

--- a/src/WinUI3-App/UnoWinUIQuickStart.Skia.WPF/UnoWinUIQuickStart.Skia.WPF.csproj
+++ b/src/WinUI3-App/UnoWinUIQuickStart.Skia.WPF/UnoWinUIQuickStart.Skia.WPF.csproj
@@ -23,11 +23,11 @@
     </AssemblyAttribute>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.44" />
-    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.44" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.44" />
-    <PackageReference Include="Uno.WinUI.Lottie" Version="4.7.44" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.9.20" />
+    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.20" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.20" />
+    <PackageReference Include="Uno.WinUI.Lottie" Version="4.9.20" />
     <PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
     <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
   </ItemGroup>

--- a/src/WinUI3-App/UnoWinUIQuickStart.Wasm/UnoWinUIQuickStart.Wasm.csproj
+++ b/src/WinUI3-App/UnoWinUIQuickStart.Wasm/UnoWinUIQuickStart.Wasm.csproj
@@ -59,15 +59,15 @@
     <None Include="wwwroot\web.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.3" />
     <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
-    <PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.44" />
-    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.44" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.44" />
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.11" />
-    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.11" />
-    <PackageReference Include="Uno.WinUI.Lottie" Version="4.7.44" />
+    <PackageReference Include="Uno.WinUI.WebAssembly" Version="4.9.20" />
+    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.20" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.20" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.24" />
+    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.24" />
+    <PackageReference Include="Uno.WinUI.Lottie" Version="4.9.20" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\UnoWinUIQuickStart\UnoWinUIQuickStart.csproj" />

--- a/src/WinUI3-App/UnoWinUIQuickStart.Windows/UnoWinUIQuickStart.Windows.csproj
+++ b/src/WinUI3-App/UnoWinUIQuickStart.Windows/UnoWinUIQuickStart.Windows.csproj
@@ -23,11 +23,9 @@
     <Content Include="Images\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230217.4" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
-    <PackageReference Include="Uno.WinUI" Version="4.7.44" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230602002" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 	<PackageReference Include="KeyboardHookLite" Version="1.1.3" Condition=" '$(Configuration)' == 'Debug' " />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/src/WinUI3-App/UnoWinUIQuickStart/Core/BaseViewModel.cs
+++ b/src/WinUI3-App/UnoWinUIQuickStart/Core/BaseViewModel.cs
@@ -2,7 +2,7 @@
 
 namespace UnoWinUIQuickStart.Core;
 
-public class BaseViewModel : INotifyPropertyChanged
+public partial class BaseViewModel : INotifyPropertyChanged
 {
 #pragma warning disable CS0067 // Justification: event is used by assembly weaver PropertyChanged.Fody
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/src/WinUI3-App/UnoWinUIQuickStart/Styles.cs
+++ b/src/WinUI3-App/UnoWinUIQuickStart/Styles.cs
@@ -6,15 +6,17 @@ namespace UnoWinUIQuickStart;
 
 public static class Styles
 {
-    public static void ClearStyles() => Implicit.ClearStyles();
-
-    // Explicit styles go here - they can follow the same pattern as implicit styles below.
-    // Since Styles is a global static using, you can then e.g. do: Button("<") .Style(HeaderButton)
-
     // Note:
     // - You can use XAML styles in C# Markup - no need to translate existing XAML styles to C#.
     // - Consider using native C# reuse mechanisms, such as builder functions or classes, instead of C# WinUI styles;
     //   WinUI styles are a primary reuse mechanism in XAML, but C# has more developer friendly alternatives
+
+    public static void ClearStyles() => Implicit.ClearStyles();
+
+#pragma warning disable IDE0002 // Simplify Member Access. Justification: allow to repeat the target class of the style in every setter, for better readability and quicker writing
+
+    // Explicit styles go here - they can follow the same pattern as implicit styles below.
+    // Since Styles is a global static using, you can then e.g. do: Button("<") .Style(HeaderButton)
 
     public static class Implicit
     {
@@ -27,14 +29,16 @@ public static class Styles
         );
 
         public static Style<Button> Buttons => buttons ??= new(
-            (Controls.Control.ForegroundProperty, White),
-            (Controls.Control.FontSizeProperty, 24)
+            (Controls.Button.ForegroundProperty, White),
+            (Controls.Button.FontSizeProperty, 24)
         );
 
         public static Style<TextBlock> TextBlocks => textBlocks ??= new(
             (Controls.TextBlock.ForegroundProperty, White),
             (Controls.TextBlock.FontSizeProperty, 24)
         );
+
+#pragma warning restore IDE0002 // Simplify Member Access
 
         internal static void ClearStyles()
         {

--- a/src/WinUI3-App/UnoWinUIQuickStart/UnoWinUIQuickStart.csproj
+++ b/src/WinUI3-App/UnoWinUIQuickStart/UnoWinUIQuickStart.csproj
@@ -33,15 +33,15 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
-    <PackageReference Include="Uno.WinUI" Version="4.7.44" />
-	<PackageReference Include="CSharpMarkup.WinUI" Version="2.0.0" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />
+    <PackageReference Include="Uno.WinUI" Version="4.9.20" />
+	<PackageReference Include="CSharpMarkup.WinUI" Version="2.1.14" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
     <PackageReference Include="PropertyChanged.Fody" Version="4.1.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net7.0-windows10.0.18362'">
-	<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230217.4" />
+	<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230602002" />
 	<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.28" />
 	<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.28" />
   </ItemGroup>


### PR DESCRIPTION
Version to 1.3.0

Update `mcs-winui3-app` template to latest stable NuGets for C# Markup 2, Windows App SDK and Uno Platform; remove unused Uno dependencies on Windows